### PR TITLE
Fix Pundit Roles and Membership Permissions

### DIFF
--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -20,12 +20,14 @@ class MembershipPolicy < ApplicationPolicy
   end
 
   def destroy?
-    membership&.admin? || record.user == user
+    return true if membership&.admin?  # Admins can remove anyone
+    return true if membership&.member? && record.user_id == membership.user_id  # Members can remove themselves
+    false
   end
 
   private
 
   def membership
-    record.organization.memberships.find_by(user:)
+    user # Because we're passing the current_membership as the pundit user
   end
 end

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -8,23 +8,21 @@ class MembershipPolicyTest < ActiveSupport::TestCase
   end
 
   def test_edit
-    assert MembershipPolicy.new(@user, @membership).edit?
+    assert MembershipPolicy.new(@membership, @membership).edit?
 
     user2 = users(:two)
-    assert_not MembershipPolicy.new(user2, @membership).edit?
+    membership2 = @organization.memberships.create(user: user2, role: :member)
+    assert_not MembershipPolicy.new(membership2, @membership).edit?
 
-    membership2 = @organization.memberships.create(user: user2, role: Membership.roles[:member])
-    assert_not MembershipPolicy.new(user2, @membership).edit?
-
-    membership2.update(role: Membership.roles[:admin])
-    assert MembershipPolicy.new(user2, @membership).edit?
+    membership2.update(role: :admin)
+    assert MembershipPolicy.new(membership2, @membership).edit?
   end
 
   def test_update
-    assert MembershipPolicy.new(@user, @membership).update?
+    assert MembershipPolicy.new(@membership, @membership).update?
   end
 
   def test_destroy
-    assert MembershipPolicy.new(@user, @membership).destroy?
+    assert MembershipPolicy.new(@membership, @membership).destroy?
   end
 end


### PR DESCRIPTION
## What changed
- Fixed membership permissions to correctly handle admin and member roles
- Fixed failing tests in MembershipPolicyTest
- Admins can now invite members to organizations if they are part of more than one organization
- Admins can now remove any member from their organization
- Members can only remove their own membership
- Corrected policy to use membership roles instead of user methods

## Why
There was an issue where:
- The add member button visibility wasn't correctly reflecting user permissions if an admin was part of more than 1 organization. For instance, if User1 was part of Org1, it would work, when they created Org2, it would be looking for User2, not User1
- The remove button visibility wasn't correctly reflecting user permissions
- Tests were failing due to incorrect role checking

## Testing
- All tests now pass
- Manually verified that:
  - Admins can see and use remove buttons for all members on their organization
  - Members can only see and use remove button for their own membership
  - "New Membership" button shows correctly for admins in all organizations