### PR TITLE
Dark mode, theming

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -8,6 +8,15 @@
   If we ever want to remove these styles, we need to add an explicit border
   color utility to any element that depends on these defaults.
 */
+@theme {
+  --color-github-navbar: #161b22;
+  --color-github-body: #22282f;
+  --color-github-favicon: #798490;
+  --color-github-button: #2b3037;
+  --color-github-text: #d2d7df;
+  --color-github-divider: #3e444c;
+}
+
 @layer base {
   *,
   ::after,
@@ -27,7 +36,7 @@
     cursor: pointer;
   }
 }
-  /* :root {
+  :root {
     --color-gray-200: #e5e7eb;
     --color-gray-400: #9ca3af;
     --color-gray-500: #6b7280;
@@ -40,7 +49,7 @@
     --color-red-500: #ef4444;
     --color-red-600: #dc2626;
     --color-red-700: #b91c1c;
-  } */
+  }
   
   @media (prefers-color-scheme: dark) {
     :root {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -8,7 +8,6 @@
   If we ever want to remove these styles, we need to add an explicit border
   color utility to any element that depends on these defaults.
 */
-
 @layer base {
   *,
   ::after,
@@ -77,4 +76,3 @@
 .form-input {
   @apply block shadow-sm rounded-md border border-gray-400 outline-hidden px-3 py-2 mt-2 w-full;
 }
-

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -8,14 +8,6 @@
   If we ever want to remove these styles, we need to add an explicit border
   color utility to any element that depends on these defaults.
 */
-@theme {
-  --color-github-navbar: #161b22;
-  --color-github-body: #22282f;
-  --color-github-favicon: #798490;
-  --color-github-button: #2b3037;
-  --color-github-text: #d2d7df;
-  --color-github-divider: #3e444c;
-}
 
 @layer base {
   *,
@@ -36,23 +28,6 @@
     cursor: pointer;
   }
 }
-  :root {
-    --color-gray-50: #f9fafb;
-    --color-gray-100: #f9fafb;
-    --color-gray-200: #e5e7eb;
-    --color-gray-400: #9ca3af;
-    --color-gray-500: #6b7280;
-    --color-gray-600: #4b5563;
-    --color-gray-700: #374151;
-    --color-gray-800: #1f2937;
-    --color-gray-900: #111827;
-    --color-blue-500: #3b82f6;
-    --color-blue-600: #2563eb;
-    --color-blue-700: #1d4ed8;
-    --color-red-500: #ef4444;
-    --color-red-600: #dc2626;
-    --color-red-700: #b91c1c;
-  }
   
   @media (prefers-color-scheme: dark) {
     :root {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -27,7 +27,7 @@
     cursor: pointer;
   }
 }
-  :root {
+  /* :root {
     --color-gray-200: #e5e7eb;
     --color-gray-400: #9ca3af;
     --color-gray-500: #6b7280;
@@ -40,7 +40,7 @@
     --color-red-500: #ef4444;
     --color-red-600: #dc2626;
     --color-red-700: #b91c1c;
-  }
+  } */
   
   @media (prefers-color-scheme: dark) {
     :root {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -37,12 +37,15 @@
   }
 }
   :root {
+    --color-gray-50: #f9fafb;
+    --color-gray-100: #f9fafb;
     --color-gray-200: #e5e7eb;
     --color-gray-400: #9ca3af;
     --color-gray-500: #6b7280;
     --color-gray-600: #4b5563;
     --color-gray-700: #374151;
     --color-gray-800: #1f2937;
+    --color-gray-900: #111827;
     --color-blue-500: #3b82f6;
     --color-blue-600: #2563eb;
     --color-blue-700: #1d4ed8;
@@ -53,12 +56,15 @@
   
   @media (prefers-color-scheme: dark) {
     :root {
+    --color-gray-50: #111827;
+    --color-gray-100: #1f2937;
     --color-gray-200: #374151;
     --color-gray-400: #6b7280;
     --color-gray-500: #9ca3af;
     --color-gray-600: #d1d5db;
     --color-gray-700: #e5e7eb;
     --color-gray-800: #f3f4f6;
+    --color-gray-900: #f9fafb;
     --color-blue-500: #2563eb;
     --color-blue-600: #1d4ed8;
     --color-blue-700: #1e40af;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -48,6 +48,41 @@
   }
 }
 
+:root.midnight {
+  --color-gray-50: #0a0c12;
+  --color-gray-100: #12151e;
+  --color-gray-200: #1a1e2a;
+  --color-gray-400: #5a6175;
+  --color-gray-500: #8a92a8;
+  --color-gray-600: #c5cbd8;
+  --color-gray-700: #e0e4ed;
+  --color-gray-800: #f0f2f7;
+  --color-gray-900: #f8f9fc;
+  --color-blue-500: #3b82f6;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+  --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+}
+
+:root.github {
+  --color-gray-50: #161b22;
+  --color-gray-100: #22282f;
+  --color-gray-200: #2b3037;
+  --color-gray-400: #798490;
+  --color-gray-500: #9ca3af;
+  --color-gray-600: #d2d7df;
+  --color-gray-700: #e5e7eb;
+  --color-gray-800: #f3f4f6;
+  --color-gray-900: #f9fafb;
+  --color-blue-500: #2563eb;
+  --color-blue-600: #1d4ed8;
+  --color-blue-700: #1e40af;
+  --color-red-500: #dc2626;
+  --color-red-600: #b91c1c;
+  --color-red-700: #991b1b;
+}
 
 .btn {
   @apply inline-flex px-4 py-2 rounded space-x-2 font-medium text-sm transition-colors ease-in-out duration-300 cursor-pointer whitespace-nowrap active:scale-95 transition-all duration-200;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -46,42 +46,42 @@
     --color-red-600: #b91c1c;
     --color-red-700: #991b1b;
   }
-}
-
-:root.midnight {
-  --color-gray-50: #0a0c12;
-  --color-gray-100: #12151e;
-  --color-gray-200: #1a1e2a;
-  --color-gray-400: #5a6175;
-  --color-gray-500: #8a92a8;
-  --color-gray-600: #c5cbd8;
-  --color-gray-700: #e0e4ed;
-  --color-gray-800: #f0f2f7;
-  --color-gray-900: #f8f9fc;
-  --color-blue-500: #3b82f6;
-  --color-blue-600: #2563eb;
-  --color-blue-700: #1d4ed8;
-  --color-red-500: #ef4444;
-  --color-red-600: #dc2626;
-  --color-red-700: #b91c1c;
-}
-
-:root.github {
-  --color-gray-50: #161b22;
-  --color-gray-100: #22282f;
-  --color-gray-200: #2b3037;
-  --color-gray-400: #798490;
-  --color-gray-500: #9ca3af;
-  --color-gray-600: #d2d7df;
-  --color-gray-700: #e5e7eb;
-  --color-gray-800: #f3f4f6;
-  --color-gray-900: #f9fafb;
-  --color-blue-500: #2563eb;
-  --color-blue-600: #1d4ed8;
-  --color-blue-700: #1e40af;
-  --color-red-500: #dc2626;
-  --color-red-600: #b91c1c;
-  --color-red-700: #991b1b;
+  
+  :root.midnight {
+    --color-gray-50: #0a0c12;
+    --color-gray-100: #12151e;
+    --color-gray-200: #1a1e2a;
+    --color-gray-400: #5a6175;
+    --color-gray-500: #8a92a8;
+    --color-gray-600: #c5cbd8;
+    --color-gray-700: #e0e4ed;
+    --color-gray-800: #f0f2f7;
+    --color-gray-900: #f8f9fc;
+    --color-blue-500: #3b82f6;
+    --color-blue-600: #2563eb;
+    --color-blue-700: #1d4ed8;
+    --color-red-500: #ef4444;
+    --color-red-600: #dc2626;
+    --color-red-700: #b91c1c;
+  }
+  
+  :root.github {
+    --color-gray-50: #161b22;
+    --color-gray-100: #22282f;
+    --color-gray-200: #2b3037;
+    --color-gray-400: #798490;
+    --color-gray-500: #9ca3af;
+    --color-gray-600: #d2d7df;
+    --color-gray-700: #e5e7eb;
+    --color-gray-800: #f3f4f6;
+    --color-gray-900: #f9fafb;
+    --color-blue-500: #2563eb;
+    --color-blue-600: #1d4ed8;
+    --color-blue-700: #1e40af;
+    --color-red-500: #dc2626;
+    --color-red-600: #b91c1c;
+    --color-red-700: #991b1b;
+  }
 }
 
 .btn {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -27,6 +27,38 @@
     cursor: pointer;
   }
 }
+  :root {
+    --color-gray-200: #e5e7eb;
+    --color-gray-400: #9ca3af;
+    --color-gray-500: #6b7280;
+    --color-gray-600: #4b5563;
+    --color-gray-700: #374151;
+    --color-gray-800: #1f2937;
+    --color-blue-500: #3b82f6;
+    --color-blue-600: #2563eb;
+    --color-blue-700: #1d4ed8;
+    --color-red-500: #ef4444;
+    --color-red-600: #dc2626;
+    --color-red-700: #b91c1c;
+  }
+  
+  @media (prefers-color-scheme: dark) {
+    :root {
+    --color-gray-200: #374151;
+    --color-gray-400: #6b7280;
+    --color-gray-500: #9ca3af;
+    --color-gray-600: #d1d5db;
+    --color-gray-700: #e5e7eb;
+    --color-gray-800: #f3f4f6;
+    --color-blue-500: #2563eb;
+    --color-blue-600: #1d4ed8;
+    --color-blue-700: #1e40af;
+    --color-red-500: #dc2626;
+    --color-red-600: #b91c1c;
+    --color-red-700: #991b1b;
+  }
+}
+
 
 .btn {
   @apply inline-flex px-4 py-2 rounded space-x-2 font-medium text-sm transition-colors ease-in-out duration-300 cursor-pointer whitespace-nowrap;
@@ -55,3 +87,4 @@
 .form-input {
   @apply block shadow-sm rounded-md border border-gray-400 outline-hidden px-3 py-2 mt-2 w-full;
 }
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full bg-gray-50 text-gray-900">
   <head>
     <%= render "layouts/head" %>
   </head>

--- a/app/views/shared/_footer_nav.html.erb
+++ b/app/views/shared/_footer_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="justify-around flex items-center lg:hidden sticky bottom-0 px-4 py-3 bg-white border-t">
+<nav class="justify-around flex items-center lg:hidden sticky bottom-0 px-4 py-3 bg-gray-100 border-t">
   <% if current_organization %>
     <%= active_link_to organization_dashboard_path(@organization), class_active: "!text-indigo-600", class: "flex flex-col items-center text-gray-600 hover:text-indigo-600 transition-colors duration-200 gap-1" do %>
       <%= inline_svg_tag "svg/home.svg", class: "size-6" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="flex justify-between px-4 py-2 bg-white border-b">
+<nav class="flex justify-between px-4 py-2 bg-gray-100 border-b">
   <div class="flex items-center gap-2">
     <% if signed_in? %>
       <button data-action="click->mobile-sidebar#open" class="lg:hidden cursor-pointer inline-flex items-center gap-2">
@@ -31,7 +31,7 @@
           <%= current_user.email %>
           <%= inline_svg_tag "svg/chevron-down.svg", class: "w-4 h-4 stroke-2 transition-transform duration-200 group-open:rotate-180" %>
         </summary>
-        <div class="absolute right-0 mt-1 bg-white border rounded-lg p-1 space-y-1">
+        <div class="absolute right-0 mt-1 bg-gray-100 border rounded-lg p-1 space-y-1">
           <%= active_link_to t("shared.navigation.edit_profile"), edit_user_registration_path, class_active: "bg-gray-200", class: "btn btn-transparent block w-full text-left" %>
           <%= button_to t("shared.navigation.logout"), destroy_user_session_path, method: :delete, data: { turbo_confirm: t("shared.actions.confirm") }, class: "btn btn-transparent block w-full text-left" %>
         </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -2,7 +2,7 @@
 <div data-mobile-sidebar-target="backdrop" class="lg:hidden fixed inset-0 bg-gray-800/50 z-40 hidden" data-action="click->mobile-sidebar#close"></div>
 
 <%# Sidebar content %>
-<aside data-mobile-sidebar-target="sidebar" class="fixed lg:relative border-r w-52 bg-white h-dvh -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 flex flex-col overflow-y-auto">
+<aside data-mobile-sidebar-target="sidebar" class="fixed lg:relative border-r w-52 bg-gray-100 h-dvh -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 flex flex-col overflow-y-auto">
   <div class="flex-1">
     <details class="group">
       <summary class="btn-transparent font-medium text-sm p-2 pl-4 cursor-pointer [&::-webkit-details-marker]:hidden flex items-center justify-between group-open:bg-gray-100">

--- a/app/views/shared/_sidebar_2_cols.html.erb
+++ b/app/views/shared/_sidebar_2_cols.html.erb
@@ -1,7 +1,7 @@
 <%# Mobile sidebar backdrop %>
 <div data-mobile-sidebar-target="backdrop" class="lg:hidden fixed inset-0 bg-gray-800/50 z-40 hidden" data-action="click->mobile-sidebar#close"></div>
 
-<aside data-mobile-sidebar-target="sidebar" class="fixed lg:relative border-r bg-white h-dvh -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 flex flex-col overflow-y-auto">
+<aside data-mobile-sidebar-target="sidebar" class="fixed lg:relative border-r bg-gray-100 h-dvh -translate-x-full lg:translate-x-0 transition-transform duration-300 z-50 flex flex-col overflow-y-auto">
   <%# Widescreen sidebar top %>
   <nav class="flex flex-row flex-grow divide-x">
     <div class="flex flex-col max-h-dvh overflow-y-auto p-2">


### PR DESCRIPTION
The trick is to use the same colors names for everything in the app. 
In this case everything is shades of `-gray-` by default. 
So I need to add dark variant only to the gray palette

apply different dark mode themes:
<img width="598" alt="Screenshot 2025-04-05 at 22 21 56" src="https://github.com/user-attachments/assets/fc97a1e5-b418-4c6f-a583-d1d8a1e3c957" />

dark example
<img width="1242" alt="Screenshot 2025-04-05 at 22 09 20" src="https://github.com/user-attachments/assets/180013ad-7a9a-46db-a2d3-161994cab267" />
light default
<img width="1245" alt="Screenshot 2025-04-05 at 22 09 37" src="https://github.com/user-attachments/assets/718adba2-0f28-4e48-a3a3-c9ab0bfe3534" />
