### PR TITLE
Add invitations management with approval/rejection by the user

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,25 @@
+class Users::InvitationsController < ApplicationController
+  before_action :set_invitation, only: [ :approve, :reject ]
+
+  def index
+    @invitations = current_user.organization_invitations.pending.includes(:organization)
+  end
+
+  def approve
+    @invitation.approve!
+    redirect_to user_invitations_path, notice: t("invitations.approve.success")
+  end
+
+  def reject
+    @invitation.reject!
+    redirect_to user_invitations_path, notice: t("invitations.reject.success")
+  end
+
+  private
+
+  def set_invitation
+    @invitation = current_user.organization_invitations.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to user_invitations_path, alert: t("invitations.errors.not_found")
+  end
+end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -1,0 +1,18 @@
+class AccessRequest < ApplicationRecord
+  belongs_to :organization
+  belongs_to :user
+  belongs_to :completed_by, class_name: "User", optional: true, foreign_key: :completed_by
+
+  enum :status, { pending: "pending", approved: "approved", rejected: "rejected" }, default: :pending
+
+  validates :status, presence: true
+  validates :user_id, uniqueness: { scope: :organization_id, message: "already has a pending request" }
+
+  def approve!
+    fail NotImplementedError, "Subclasses must implement this method"
+  end
+
+  def reject!
+    fail NotImplementedError, "Subclasses must implement this method"
+  end
+end

--- a/app/models/access_request/invite_to_organization.rb
+++ b/app/models/access_request/invite_to_organization.rb
@@ -1,0 +1,18 @@
+class AccessRequest::InviteToOrganization < AccessRequest
+  validates :type, presence: true
+
+  store :resources, accessors: [ :organization_role ]
+
+  def approve!
+    transaction do
+      update!(status: :approved, completed_by: user)
+      user.memberships.create(organization: organization, role: organization_role)
+    end
+  rescue => e
+    raise ActiveRecord::Rollback, e.message
+  end
+
+  def reject!
+    update!(status: :rejected, completed_by: user)
+  end
+end

--- a/app/models/access_request/user_request_for_organization.rb
+++ b/app/models/access_request/user_request_for_organization.rb
@@ -1,0 +1,5 @@
+class AccessRequest::UserRequestForOrganization < AccessRequest
+  validates :type, presence: true
+
+  store :resources, accessors: [ :organization_role ]
+end

--- a/app/models/membership_invitation.rb
+++ b/app/models/membership_invitation.rb
@@ -13,7 +13,7 @@ class MembershipInvitation
     user = find_or_invite_user
     return false unless user&.valid?
 
-    add_user_to_organization(user)
+    create_access_request(user)
   end
 
   private
@@ -22,13 +22,13 @@ class MembershipInvitation
     User.find_by(email: email) || User.invite!({ email: }, inviter)
   end
 
-  def add_user_to_organization(user)
+  def create_access_request(user)
     membership = user.memberships.find_by(organization: organization)
     if membership.present?
       errors.add(:base, "#{email} is already a member of this organization.")
       false
     else
-      user.memberships.create(organization: organization, role: role)
+      AccessRequest::InviteToOrganization.create(user:, organization:, organization_role: role)
       true
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,11 @@ class Organization < ApplicationRecord
   has_many :users, through: :memberships
   belongs_to :owner, class_name: "User"
 
+  has_many :user_invitations, class_name: "AccessRequest::InviteToOrganization", dependent: :destroy
+  has_many :user_requests, class_name: "AccessRequest::UserRequestForOrganization", dependent: :destroy
+
+  enum :privacy_setting, { private: "private", restricted: "restricted", public: "public" }, default: :private, prefix: true
+
   include Transfer
 
   has_many :projects, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
   include User::Authentication
   include User::Multitenancy
+
+  has_many :organization_invitations, class_name: "AccessRequest::InviteToOrganization", dependent: :destroy
+  has_many :organization_requests, class_name: "AccessRequest::UserRequestForOrganization", dependent: :destroy
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -32,6 +32,7 @@
           <%= inline_svg_tag "svg/chevron-down.svg", class: "w-4 h-4 stroke-2 transition-transform duration-200 group-open:rotate-180" %>
         </summary>
         <div class="absolute right-0 mt-1 bg-gray-100 border rounded-lg p-1 space-y-1">
+          <%= active_link_to t("shared.navigation.pending_invitations"), user_invitations_path, class_active: "bg-gray-200", class: "btn btn-transparent block w-full text-left" %>
           <%= active_link_to t("shared.navigation.edit_profile"), edit_user_registration_path, class_active: "bg-gray-200", class: "btn btn-transparent block w-full text-left" %>
           <%= button_to t("shared.navigation.logout"), destroy_user_session_path, method: :delete, data: { turbo_confirm: t("shared.actions.confirm") }, class: "btn btn-transparent block w-full text-left" %>
         </div>

--- a/app/views/users/access_request/invite_to_organizations/_invite_to_organization.html.erb
+++ b/app/views/users/access_request/invite_to_organizations/_invite_to_organization.html.erb
@@ -1,0 +1,14 @@
+<div class="border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100">
+  <div class="flex items-center gap-2">
+    <%= "Organization: #{invitation.organization.name}" %>
+    <br>
+    <%= "Role: #{invitation.organization_role}" %>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-1">
+      <%= button_to t("invitations.buttons.approve"), approve_user_invitation_path(invitation), method: :post, class: "btn btn-primary" %>
+      <%= button_to t("invitations.buttons.reject"), reject_user_invitation_path(invitation), method: :post, class: "btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/invitations/index.html.erb
+++ b/app/views/users/invitations/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, t("invitations.index.title") %>
+
+<%= render PageComponent.new(title: t("invitations.index.title")) do |component| %>
+  <div id="invitations" class="space-y-4">
+    <% @invitations.each do |invitation| %>
+      <%= render invitation, invitation: %>
+    <% end %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,18 @@ en:
         success: Ownership transferred
     update:
       success: Organization updated
+  invitations:
+    index:
+      title: Pending invitations
+    approve:
+      success: Invitation approved
+    reject:
+      success: Invitation rejected
+    buttons:
+      approve: Join
+      reject: Reject
+    errors:
+      not_found: Invitation not found
   shared:
     actions:
       cancel: Cancel
@@ -82,6 +94,7 @@ en:
       logout: Log out
       register: Register
       select_organization: Select organization
+      pending_invitations: Pending invitations
   static:
     pricing:
       title: Pricing

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,17 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: "users/registrations", sessions: "users/sessions" }
 
+  resource :user do
+    scope module: :users do
+      resources :invitations, only: %i[index] do
+        member do
+          post :approve
+          post :reject
+        end
+      end
+    end
+  end
+
   resources :organizations, path: I18n.t("routes.organizations") do
     scope module: :organizations do
       resources :memberships, except: %i[show], path: I18n.t("routes.memberships")

--- a/db/migrate/20250430015739_privacy_settings.rb
+++ b/db/migrate/20250430015739_privacy_settings.rb
@@ -1,0 +1,18 @@
+class PrivacySettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organizations, :privacy_setting, :string, default: "private", null: false
+
+    create_table :access_requests do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :status, null: false, default: 'pending'
+      t.bigint :completed_by
+      t.string :type
+      t.json :resources
+
+      t.timestamps
+    end
+
+    add_foreign_key :access_requests, :users, column: :completed_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_13_113043) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_30_015739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "access_requests", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.bigint "user_id", null: false
+    t.string "status", default: "pending", null: false
+    t.bigint "completed_by"
+    t.string "type"
+    t.json "resources"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_access_requests_on_organization_id"
+    t.index ["user_id"], name: "index_access_requests_on_user_id"
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -59,6 +72,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_13_113043) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "owner_id", null: false
+    t.string "privacy_setting", default: "private", null: false
     t.index ["owner_id"], name: "index_organizations_on_owner_id"
   end
 
@@ -333,6 +347,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_13_113043) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "access_requests", "organizations"
+  add_foreign_key "access_requests", "users"
+  add_foreign_key "access_requests", "users", column: "completed_by"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "memberships", "organizations"

--- a/test/controllers/organizations/memberships_controller_test.rb
+++ b/test/controllers/organizations/memberships_controller_test.rb
@@ -37,7 +37,7 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test "should create membership" do
+  test "should create access request" do
     email = "julia@superails.com"
 
     # nil email
@@ -73,13 +73,13 @@ class MembershipsControllerTest < ActionDispatch::IntegrationTest
 
     # success
     assert_difference("User.count") do
-      assert_difference("Membership.count") do
+      assert_difference("AccessRequest::InviteToOrganization.count") do
         post organization_memberships_url(@organization), params: { membership_invitation: { email:, role: "member" } }
       end
     end
 
     assert_redirected_to organization_memberships_url
-    assert @organization.users.find_by(email:)
+    assert_equal "julia@superails.com", @organization.user_invitations.last.user.email
 
     # when user is already a member
     assert_no_difference("User.count") do

--- a/test/controllers/users/invitations_controller_test.rb
+++ b/test/controllers/users/invitations_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Users::InvitationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @invitation = access_requests(:invite_to_organization_one)
+    @unassociated_user = users(:unassociated)
+    sign_in @unassociated_user
+  end
+
+  test "should get index" do
+    get user_invitations_url
+    assert_response :success
+
+    assert_match @invitation.organization.name, response.body
+    organization2 = organizations(:two)
+    assert_no_match organization2.name, response.body
+  end
+
+  test "should approve invitation" do
+    assert_difference "@unassociated_user.memberships.count", 1 do
+      post approve_user_invitation_url(@invitation)
+    end
+
+    assert_redirected_to user_invitations_url
+    assert_equal I18n.t("invitations.approve.success"), flash[:notice]
+    assert_equal "approved", @invitation.reload.status
+  end
+
+  test "should reject invitation" do
+    assert_difference "@unassociated_user.memberships.count", 0 do
+      post reject_user_invitation_url(@invitation)
+    end
+
+    assert_redirected_to user_invitations_url
+    assert_equal I18n.t("invitations.reject.success"), flash[:notice]
+    assert_equal "rejected", @invitation.reload.status
+  end
+
+  test "should not approve invitation if not signed in" do
+    sign_out @unassociated_user
+    post approve_user_invitation_url(@invitation)
+    assert_redirected_to new_user_session_url
+  end
+
+  test "should not reject invitation if not signed in" do
+    sign_out @unassociated_user
+    post reject_user_invitation_url(@invitation)
+    assert_redirected_to new_user_session_url
+  end
+
+  test "should not approve another user's invitation" do
+    other_user_invitation = access_requests(:invite_to_organization_two)
+
+    post approve_user_invitation_url(other_user_invitation)
+    assert_redirected_to user_invitations_url
+    assert_equal I18n.t("invitations.errors.not_found"), flash[:alert]
+  end
+
+  test "should not reject another user's invitation" do
+    other_user_invitation = access_requests(:invite_to_organization_two)
+
+    post reject_user_invitation_url(other_user_invitation)
+    assert_redirected_to user_invitations_url
+    assert_equal I18n.t("invitations.errors.not_found"), flash[:alert]
+  end
+end

--- a/test/fixtures/access_requests.yml
+++ b/test/fixtures/access_requests.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+invite_to_organization_one:
+  organization: one
+  user: unassociated
+  status: pending
+  type: AccessRequest::InviteToOrganization
+  resources: '{ "organization_role": "member" }'
+
+invite_to_organization_two:
+  organization: two
+  user: one
+  status: pending
+  type: AccessRequest::InviteToOrganization
+  resources: '{ "organization_role": "member" }'

--- a/test/models/access_request/invite_to_organization_test.rb
+++ b/test/models/access_request/invite_to_organization_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class AccessRequest::InviteToOrganizationTest < ActiveSupport::TestCase
+  test "should return the role from the resources" do
+    access_request = access_requests(:invite_to_organization_one)
+    assert_equal "member", access_request.organization_role
+  end
+
+  test "when approved, creates a membership" do
+    access_request = access_requests(:invite_to_organization_one)
+    user = access_request.user
+    assert_difference "Membership.count", 1 do
+      access_request.approve!
+    end
+
+    assert_equal "approved", access_request.reload.status
+    assert_equal access_request.organization_role, user.memberships.last.role
+  end
+
+  test "when rejected, updates the access request status" do
+    access_request = access_requests(:invite_to_organization_one)
+    assert_difference "Membership.count", 0 do
+      access_request.reject!
+    end
+
+    assert_equal "rejected", access_request.reload.status
+  end
+end

--- a/test/models/access_request_test.rb
+++ b/test/models/access_request_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class AccessRequestTest < ActiveSupport::TestCase
+  test "should not be valid if user already has an access request for that organization" do
+    access_request = AccessRequest.new(user: users(:one), organization: organizations(:two))
+    assert_not access_request.valid?
+    assert_includes access_request.errors.messages[:user_id], "already has a pending request"
+  end
+
+  test "should return only pending access requests" do
+    rejected_access_request = AccessRequest.create!(status: :rejected, user: users(:one), organization: organizations(:one))
+    pending_access_requests = AccessRequest.pending
+
+    assert_equal 2, pending_access_requests.count
+    assert_includes pending_access_requests, access_requests(:invite_to_organization_one)
+    assert_includes pending_access_requests, access_requests(:invite_to_organization_two)
+    assert_not_includes pending_access_requests, rejected_access_request
+  end
+
+  test "approve" do
+    access_request = AccessRequest.new
+    assert_raises NotImplementedError do
+      access_request.approve!
+    end
+  end
+
+  test "reject" do
+    access_request = AccessRequest.new
+    assert_raises NotImplementedError do
+      access_request.reject!
+    end
+  end
+end

--- a/test/models/membership_invitation_test.rb
+++ b/test/models/membership_invitation_test.rb
@@ -9,7 +9,7 @@ class MembershipInvitationTest < ActiveSupport::TestCase
     @first_admin_membership = @organization.memberships.admin.first
   end
 
-  test "valid invitation with correct attributes" do
+  test "valid membership invitation with correct attributes creates an access request" do
     invitation = MembershipInvitation.new(
       email: "newuser@example.com",
       organization: @organization,
@@ -18,14 +18,14 @@ class MembershipInvitationTest < ActiveSupport::TestCase
     )
     assert invitation.valid?
     assert_difference -> { User.count }, 1 do
-      assert_difference -> { Membership.count }, 1 do
+      assert_difference -> { AccessRequest::InviteToOrganization.count }, 1 do
         assert invitation.save
       end
     end
 
     user = User.find_by(email: "newuser@example.com")
     assert user.present?
-    assert user.memberships.exists?(organization: @organization)
+    assert_equal "newuser@example.com", @organization.user_invitations.last.user.email
   end
 
   test "invalid with incorrect email format" do


### PR DESCRIPTION
- Introduced InvitationsController to handle listing, approving, and rejecting invitations.
- Created AccessRequest model for managing access requests with pending, approved, and rejected statuses.
- Updated MembershipInvitation to create access requests instead of directly adding users to organizations.
- Added views for displaying and managing invitations.
- Enhanced organization and user models to support new access request associations.
- Implemented privacy settings for organizations and updated database schema accordingly.
- Added localization for invitation messages.

This PR implements Step 1 commented in this issue #226 