### PR TITLE
Add SimpleCov for test coverage tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 /config/credentials/test.key
 
 /config/credentials/production.key
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "simplecov", "~> 0.22.0", require: false
 end
 
 # active record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
     devise_invitable (2.0.9)
       actionmailer (>= 5.0)
       devise (>= 4.6)
+    docile (1.4.1)
     dotenv (3.1.7)
     drb (2.2.1)
     ed25519 (1.3.0)
@@ -343,6 +344,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     solid_cable (3.0.7)
       actioncable (>= 7.2)
@@ -448,6 +455,7 @@ DEPENDENCIES
   rails (~> 8.0.1)
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov (~> 0.22.0)
   solid_cable
   solid_cache
   solid_queue

--- a/test/supports/simplecov.rb
+++ b/test/supports/simplecov.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+Rake.respond_to?(:application) &&
+  Rake.application.respond_to?(:top_level_tasks) &&
+  Rake.application.top_level_tasks.any? { |e| e.eql?("test:prepare") }
+
+FileUtils.rm_f("coverage/.resultset.json")
+
+SimpleCov.minimum_coverage 80
+
+SimpleCov.start(:rails) do
+  # Ignore files without functional code
+  add_filter do |source_file|
+    source = source_file.src
+    ignored = source.reduce(0) do |ignored, line|
+      case line.strip
+      when /^$/, /^#/, /^class/, /^module/, /^end/
+        ignored += 1
+      end
+      ignored
+    end
+    (source.count - ignored) <= 0
+  end
+
+  enable_coverage :branch
+
+  add_group "Policies", "app/policies"
+
+  at_exit do
+    SimpleCov.formatter = SimpleCov::Formatter::SimpleFormatter
+    SimpleCov.result.format!
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,18 @@
 ENV["RAILS_ENV"] ||= "test"
+
+require_relative "supports/simplecov"
 require_relative "../config/environment"
 require "rails/test_help"
 
 module ActiveSupport
   class TestCase
     include Devise::Test::IntegrationHelpers
+
     # Run tests in parallel with specified workers
+    parallelize_setup do |_worker|
+      SimpleCov.command_name "Job::#{Process.pid}" if const_defined?(:SimpleCov)
+    end
+
     parallelize(workers: :number_of_processors)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
- Updated .gitignore to exclude coverage directory.
- Added SimpleCov gem to Gemfile for test coverage analysis.
- Configured SimpleCov in a new support file to customize reporting.
- Integrated SimpleCov setup in test_helper.rb for parallel test execution.