### PR TITLE
Add Organization Privacy Settings Management

### DIFF
--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Organizations::InvitationsController < Organizations::BaseController
+  before_action :set_invitation, only: %i[destroy]
+
+  def index
+    @invitations = @organization.user_invitations.pending
+  end
+
+  def destroy
+    @invitation.destroy
+    redirect_to organization_invitations_path(@organization), notice: t("organizations.invitations.destroy.success")
+  end
+
+  private
+
+  def set_invitation
+    @invitation = @organization.user_invitations.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to organization_invitations_path(@organization), alert: t("organizations.invitations.errors.not_found")
+  end
+end

--- a/app/views/organizations/access_request/invite_to_organizations/_invite_to_organization.html.erb
+++ b/app/views/organizations/access_request/invite_to_organizations/_invite_to_organization.html.erb
@@ -1,0 +1,13 @@
+<div class="border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100">
+  <div class="flex items-center gap-2">
+    <%= "User email: #{invitation.user.email}" %>
+    <br>
+    <%= "Role: #{invitation.organization_role}" %>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-1">
+      <%= button_to t("organizations.invitations.buttons.cancel"), organization_invitation_path(invitation.organization, invitation), method: :delete, class: "btn btn-danger" %>
+    </div>
+  </div>
+</div>

--- a/app/views/organizations/invitations/index.html.erb
+++ b/app/views/organizations/invitations/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, t("organizations.invitations.index.title") %>
+
+<%= render PageComponent.new(title: t("organizations.invitations.index.page_title", organization: @organization.name)) do |component| %>
+  <div id="invitations" class="space-y-4">
+    <% @invitations.each do |invitation| %>
+      <%= render invitation, invitation: %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/organizations/memberships/index.html.erb
+++ b/app/views/organizations/memberships/index.html.erb
@@ -1,5 +1,46 @@
 <% content_for :title, t(".title") %>
 
+<% if policy(@current_membership).update? %>
+  <%= render PageComponent.new(title: t("organizations.show.access_settings.title", )) do %>
+    <%= form_with model: @organization, method: :patch do |form| %>
+      <%= form.label :privacy_setting, t("organizations.show.access_settings.privacy") %>
+      <%= form.select :privacy_setting, Organization.privacy_settings.keys.map { |k| [k.humanize, k] }, {}, { class: "form-input", onchange: "this.form.submit()" } %>
+    <% end %>
+
+    <%= link_to organization_invitations_path(@organization), class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
+      <div class="flex items-center gap-2">
+        <%= t("organizations.show.access_settings.invitations") %>
+      </div>
+
+      <div class="flex items-center gap-4">
+        <div class="flex items-center -space-x-2">
+          <%= @organization.user_invitations.pending.count %>
+        </div>
+
+        <%= inline_svg_tag "svg/chevron-right.svg", class: "size-5" %>
+      </div>
+    <% end %>
+
+    <% if @organization.privacy_setting_restricted? %>
+      <%= link_to "#", class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
+        <div class="flex items-center gap-2">
+          <%= t("organizations.show.access_settings.requests_to_join_organization") %>
+        </div>
+
+        <div class="flex items-center gap-4">
+          <div class="flex items-center -space-x-2">
+            <%= @organization.user_requests.pending.count %>
+          </div>
+
+          <%= inline_svg_tag "svg/chevron-right.svg", class: "size-5" %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<br>
+
 <%= render PageComponent.new(title: t(".title")) do |component| %>
   <% component.with_action_list do %>
     <%= link_to t("organizations.memberships.new.title"), new_organization_membership_path(@organization), class: "btn btn-primary" if policy(@organization.memberships.new).new? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,11 @@ en:
       title: New organization
     show:
       title: Organization settings
+      access_settings:
+        title: Access Settings
+        privacy: Privacy type
+        invitations: Pending invitations
+        requests_to_join_organization: Pending requests to join organization
     subscriptions:
       features:
         title: Features
@@ -65,6 +70,17 @@ en:
         success: Ownership transferred
     update:
       success: Organization updated
+      error: An error occurred while updating the organization
+    invitations:
+      index:
+        title: Pending invitations
+        page_title: Pending invitations for %{organization}
+      destroy:
+        success: Invitation cancelled
+      buttons:
+        cancel: Cancel invitation
+      errors:
+        not_found: Invitation not found
   invitations:
     index:
       title: Pending invitations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       resources :memberships, except: %i[show], path: I18n.t("routes.memberships")
       resource :transfer, only: %i[show update]
       resources :projects
+      resources :invitations, only: %i[index destroy]
 
       get "dashboard", to: "dashboard#index"
       get "paywalled_page", to: "dashboard#paywalled_page"

--- a/test/controllers/organizations/invitations_controller_test.rb
+++ b/test/controllers/organizations/invitations_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @organization = organizations(:one)
+    @user = users(:one)
+    @invitation = access_requests(:invite_to_organization_one)
+    sign_in @user
+  end
+
+  test "should get index" do
+    get organization_invitations_url(@organization)
+    assert_response :success
+  end
+
+  test "should get index and show only pending invitations" do
+    pending_invitations = @organization.user_invitations.pending.to_a
+
+    approved_invitation = @organization.user_invitations.create!(
+      user: users(:two),
+      status: :approved,
+      resources: { organization_role: "member" }.to_json
+    )
+
+    get organization_invitations_url(@organization)
+    assert_response :success
+
+    pending_invitations.each do |invitation|
+      assert_match invitation.user.email, response.body
+    end
+
+    assert_no_match approved_invitation.user.email, response.body
+  end
+
+  test "#destroy removes invitation" do
+    assert_difference("AccessRequest.count", -1) do
+      delete organization_invitation_url(@organization, @invitation)
+    end
+    assert_redirected_to organization_invitations_path(@organization)
+    assert_equal I18n.t("organizations.invitations.destroy.success"), flash[:notice]
+  end
+
+  test "#destroy redirects with alert when invitation not found" do
+    delete organization_invitation_url(@organization, id: "nonexistent")
+    assert_redirected_to organization_invitations_path(@organization)
+    assert_equal I18n.t("organizations.invitations.errors.not_found"), flash[:alert]
+  end
+end

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -49,7 +49,9 @@ class OrganizationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update organization" do
-    patch organization_url(@organization), params: { organization: { name: @organization.name } }
+    patch organization_url(@organization),
+            params: { organization: { name: @organization.name } },
+            headers: { "HTTP_REFERER" => organization_path(@organization) }
     assert_redirected_to organization_url(@organization)
   end
 
@@ -59,6 +61,29 @@ class OrganizationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
     assert_equal organization.name, organization.reload.name
     assert_equal "You are not authorized to perform this action.", flash[:alert]
+  end
+
+  test "should update organization and respect referer from memberships path" do
+    memberships_path = organization_memberships_path(@organization)
+
+    patch organization_url(@organization),
+          params: { organization: { name: @organization.name } },
+          headers: { "HTTP_REFERER" => memberships_path }
+
+    assert_redirected_to memberships_path
+    assert_equal I18n.t("organizations.update.success"), flash[:notice]
+  end
+
+  test "should handle failed update with memberships referer" do
+    memberships_path = organization_memberships_path(@organization)
+
+    # Force validation failure by using empty name
+    patch organization_url(@organization),
+          params: { organization: { name: "" } },
+          headers: { "HTTP_REFERER" => memberships_path }
+
+    assert_redirected_to memberships_path
+    assert_equal I18n.t("organizations.update.error"), flash[:alert]
   end
 
   test "only admin can destroy organization" do


### PR DESCRIPTION
- Added Organizations::InvitationsController for managing user invitations.
- Introduced Organizations::RequestsToJoinController for handling requests to join.
- Enhanced organization show view with access settings for privacy and invitations.

These changes implements Step 2 commented in this issue #226.