### PR TITLE
Adds discover feature with organizations listing

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,0 +1,16 @@
+<div class="du-card bg-base-100 shadow-sm max-w-xl">
+  <% if image? %>
+    <%= image %>
+  <% end %>
+  <div class="du-card-body">
+    <h2 class="du-card-title"><%= title %></h2>
+    <p><%= description %></p>
+    <div class="du-card-actions justify-end">
+      <% if actions? %>
+        <% actions.each do |action| %>
+          <%= action %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CardComponent < ViewComponent::Base
+  renders_one :image
+  renders_many :actions
+
+  attr_reader :title, :description
+
+  def initialize(title:, description:)
+    @title = title
+    @description = description
+  end
+end

--- a/app/controllers/discovers_controller.rb
+++ b/app/controllers/discovers_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DiscoversController < ApplicationController
+  def show
+    @organizations = Organization.not_privacy_setting_private
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,4 +33,8 @@ class Organization < ApplicationRecord
   def pay_should_sync_customer?
     super || saved_change_to_owner_id?
   end
+
+  def participant?(user)
+    users.include?(user)
+  end
 end

--- a/app/views/discovers/_organization.html.erb
+++ b/app/views/discovers/_organization.html.erb
@@ -1,0 +1,14 @@
+<%= render CardComponent.new(title: organization.name, description: "Members: #{organization.users.count}") do |card| %>
+  <% card.with_image do %>
+    <%= organization_avatar(organization, classes: "max-w-full h-80 object-cover") %>
+  <% end %>
+  <% card.with_action do %>
+    <% if organization.participant?(current_user) %>
+      <%= link_to t("discovers.show.actions.open"), organization_dashboard_path(organization), class: "du-btn du-btn-primary" %>
+    <% else %>
+      <%= button_to t("discovers.show.actions.#{organization.privacy_setting_public? ? "join" : "request_to_join"}"), "#",
+        method: :post,
+        class: "du-btn du-btn-primary" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/discovers/show.html.erb
+++ b/app/views/discovers/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, t(".title") %>
+
+<%= render PageComponent.new(title: t(".page_title"), full_width: true) do |component| %>
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <% @organizations.each do |organization| %>
+      <%= render "discovers/organization", organization: organization %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/organizations/access_request/invite_to_organizations/_invite_to_organization.html.erb
+++ b/app/views/organizations/access_request/invite_to_organizations/_invite_to_organization.html.erb
@@ -7,7 +7,7 @@
 
   <div class="flex items-center gap-4">
     <div class="flex items-center gap-1">
-      <%= button_to t("organizations.invitations.buttons.cancel"), organization_invitation_path(invitation.organization, invitation), method: :delete, class: "btn btn-danger" %>
+      <%= button_to t("organizations.invitations.buttons.cancel"), organization_invitation_path(invitation.organization, invitation), method: :delete, class: "du-btn du-btn-error" %>
     </div>
   </div>
 </div>

--- a/app/views/organizations/memberships/index.html.erb
+++ b/app/views/organizations/memberships/index.html.erb
@@ -1,15 +1,15 @@
 <% content_for :title, t(".title") %>
 
 <% if policy(@current_membership).update? %>
-  <%= render PageComponent.new(title: t("organizations.show.access_settings.title", )) do %>
+  <%= render PageComponent.new(title: t(".access_settings.title", )) do %>
     <%= form_with model: @organization, method: :patch do |form| %>
-      <%= form.label :privacy_setting, t("organizations.show.access_settings.privacy") %>
+      <%= form.label :privacy_setting, t(".access_settings.privacy") %>
       <%= form.select :privacy_setting, Organization.privacy_settings.keys.map { |k| [k.humanize, k] }, {}, { class: "form-input", onchange: "this.form.submit()" } %>
     <% end %>
 
     <%= link_to organization_invitations_path(@organization), class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
       <div class="flex items-center gap-2">
-        <%= t("organizations.show.access_settings.invitations") %>
+        <%= t(".access_settings.invitations") %>
       </div>
 
       <div class="flex items-center gap-4">
@@ -24,7 +24,7 @@
     <% if @organization.privacy_setting_restricted? %>
       <%= link_to "#", class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
         <div class="flex items-center gap-2">
-          <%= t("organizations.show.access_settings.requests_to_join_organization") %>
+          <%= t(".access_settings.requests_to_join_organization") %>
         </div>
 
         <div class="flex items-center gap-4">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,6 +14,8 @@
           </div>
         <% end %>
       </button>
+
+      <%= active_link_to t("shared.navigation.discover"), discover_path, class_active: "du-btn-active", class: "du-btn du-btn-ghost" %>
     <% else %>
       <%= link_to root_path, class: "no-underline" do %>
         <%= image_tag "logo.png", class: "size-8" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,14 @@ en:
         cancel: Cancel invitation
       errors:
         not_found: Invitation not found
+  discovers:
+    show:
+      title: Discover
+      page_title: Choose your next organization
+      actions:
+        join: Join
+        request_to_join: Request to join
+        open: Open
   invitations:
     index:
       title: Pending invitations
@@ -111,6 +119,7 @@ en:
       register: Register
       select_organization: Select organization
       pending_invitations: Pending invitations
+      discover: Discover Organizations
   static:
     pricing:
       title: Pricing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,11 @@ en:
         you_have_left_the_organization: You have left the organization
       index:
         title: Teammates
+        access_settings:
+          title: Access Settings
+          privacy: Privacy type
+          invitations: Pending invitations
+          requests_to_join_organization: Pending requests to join organization
       new:
         title: Invite teammate
       update:
@@ -37,11 +42,6 @@ en:
       title: New organization
     show:
       title: Organization settings
-      access_settings:
-        title: Access Settings
-        privacy: Privacy type
-        invitations: Pending invitations
-        requests_to_join_organization: Pending requests to join organization
     subscriptions:
       features:
         title: Features

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: "users/registrations", sessions: "users/sessions" }
 
+  resource :discover, only: %i[show]
+
   resource :user do
     scope module: :users do
       resources :invitations, only: %i[index] do

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CardComponentTest < ViewComponent::TestCase
+  def test_render_card_component
+    render_inline(CardComponent.new(title: "Hello, card!", description: "This is a test card."))
+
+    assert_component_rendered
+
+    assert_text "Hello, card!"
+    assert_text "This is a test card."
+  end
+end

--- a/test/controllers/discovers_controller_test.rb
+++ b/test/controllers/discovers_controller_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DiscoversControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    sign_in users(:one)
+
+    get discover_path
+    assert_response :success
+  end
+
+  test "should not get show if not signed in" do
+    get discover_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "should see only public and restricted organizations" do
+    sign_in users(:one)
+
+    organization1 = Organization.create!(privacy_setting: :public, owner: users(:one), name: "Organization One")
+    organization2 = Organization.create!(privacy_setting: :restricted, owner: users(:one), name: "Organization Two")
+    organization3 = Organization.create!(privacy_setting: :private, owner: users(:one), name: "Organization Three")
+
+    get discover_path
+    assert_response :success
+    assert_select "h1", I18n.t("discovers.show.page_title")
+    assert_includes response.body, organization1.name
+    assert_includes response.body, organization2.name
+    assert_not_includes response.body, organization3.name
+  end
+end


### PR DESCRIPTION
- Introduced CardComponent for displaying organizations with images and actions.
- Added discoverable scope to the Organization model for filtering based on privacy settings.

This PR implements Step 3 described on issue #226.