### PR TITLE
Add Membership Request Management Functionality

### DIFF
--- a/app/controllers/organizations/membership_requests_controller.rb
+++ b/app/controllers/organizations/membership_requests_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Organizations::MembershipRequestsController < Organizations::BaseController
+  before_action :set_membership_request, only: %i[approve reject  ]
+
+  def index
+    @membership_requests = @organization.user_requests.pending
+  end
+
+  def approve
+    @membership_request.approve!(completed_by: current_user)
+    redirect_to organization_membership_requests_path(@organization), notice: t("membership_requests.approve.success")
+  end
+
+  def reject
+    @membership_request.reject!(completed_by: current_user)
+    redirect_to organization_membership_requests_path(@organization), notice: t("membership_requests.reject.success")
+  end
+
+  private
+
+  def set_membership_request
+    @membership_request = @organization.user_requests.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to organization_membership_requests_path(@organization), alert: t("membership_requests.errors.not_found")
+  end
+end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -7,12 +7,12 @@ class Users::InvitationsController < ApplicationController
 
   def approve
     @invitation.approve!
-    redirect_to user_invitations_path, notice: t("invitations.approve.success")
+    redirect_back(fallback_location: user_invitations_path, notice: t("invitations.approve.success"))
   end
 
   def reject
     @invitation.reject!
-    redirect_to user_invitations_path, notice: t("invitations.reject.success")
+    redirect_back(fallback_location: user_invitations_path, notice: t("invitations.reject.success"))
   end
 
   private

--- a/app/controllers/users/membership_requests_controller.rb
+++ b/app/controllers/users/membership_requests_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Users::MembershipRequestsController < ApplicationController
+  before_action :set_organization
+
+  def create
+    request = MembershipRequest.new(organization: @organization, user: current_user)
+    if request.save
+      flash[:notice] = t("membership_requests.success")
+    else
+      flash[:alert] = request.errors.full_messages.join(", ")
+    end
+
+    render turbo_stream: [
+      turbo_stream.replace("organization_#{@organization.id}",
+                          partial: "discovers/organization",
+                          locals: { organization: @organization }),
+      turbo_stream.update("flash", partial: "shared/flash")
+    ]
+  end
+
+  private
+
+  def set_organization
+    @organization = Organization.find(params[:organization_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_back(fallback_location: discover_path, alert: t("organizations.errors.not_found"))
+  end
+end

--- a/app/models/access_request/user_request_for_organization.rb
+++ b/app/models/access_request/user_request_for_organization.rb
@@ -2,4 +2,17 @@ class AccessRequest::UserRequestForOrganization < AccessRequest
   validates :type, presence: true
 
   store :resources, accessors: [ :organization_role ]
+
+  def approve!(completed_by:)
+    transaction do
+      update!(status: :approved, completed_by:)
+      organization.memberships.create(user:, role: organization_role)
+    end
+  rescue => e
+    raise ActiveRecord::Rollback, e.message
+  end
+
+  def reject!(completed_by:)
+    update!(status: :rejected, completed_by:)
+  end
 end

--- a/app/models/membership_invitation.rb
+++ b/app/models/membership_invitation.rb
@@ -28,7 +28,7 @@ class MembershipInvitation
       errors.add(:base, "#{email} is already a member of this organization.")
       false
     else
-      AccessRequest::InviteToOrganization.create(user:, organization:, organization_role: role)
+      organization.user_invitations.create(user:, organization_role: role)
       true
     end
   end

--- a/app/models/membership_request.rb
+++ b/app/models/membership_request.rb
@@ -1,0 +1,46 @@
+class MembershipRequest
+  include ActiveModel::Model
+
+  attr_accessor :organization, :user
+
+  validates :organization, presence: true
+  validates :user, presence: true
+
+  def save
+    return false unless valid?
+
+    return false if user_already_participant?
+
+    return false if organization.privacy_setting_private?
+
+    request_access
+  end
+
+  private
+
+  def user_already_participant?
+    return false if user.memberships.find_by(organization: organization).blank?
+
+    errors.add(:base, I18n.t("membership_requests.errors.already_participant"))
+    true
+  end
+
+  def request_access
+    if organization.privacy_setting_public?
+      user.memberships.create(organization:, role:)
+    elsif organization.privacy_setting_restricted?
+      if user.organization_requests.find_by(organization:).present?
+        errors.add(:base, I18n.t("membership_requests.errors.already_requested"))
+        return false
+      end
+
+      user.organization_requests.create(organization:, organization_role: role)
+    end
+
+    true
+  end
+
+  def role
+    Membership.roles[:member]
+  end
+end

--- a/app/views/discovers/_organization.html.erb
+++ b/app/views/discovers/_organization.html.erb
@@ -1,14 +1,23 @@
-<%= render CardComponent.new(title: organization.name, description: "Members: #{organization.users.count}") do |card| %>
-  <% card.with_image do %>
-    <%= organization_avatar(organization, classes: "max-w-full h-80 object-cover") %>
-  <% end %>
-  <% card.with_action do %>
-    <% if organization.participant?(current_user) %>
-      <%= link_to t("discovers.show.actions.open"), organization_dashboard_path(organization), class: "du-btn du-btn-primary" %>
-    <% else %>
-      <%= button_to t("discovers.show.actions.#{organization.privacy_setting_public? ? "join" : "request_to_join"}"), "#",
-        method: :post,
-        class: "du-btn du-btn-primary" %>
+<%= turbo_frame_tag "organization_#{organization.id}" do %>
+  <%= render CardComponent.new(title: organization.name, description: "Members: #{organization.users.count}") do |card| %>
+    <% card.with_image do %>
+      <%= organization_avatar(organization, classes: "max-w-full h-80 object-cover") %>
+    <% end %>
+    <% card.with_action do %>
+      <% if organization.participant?(current_user) %>
+        <%= link_to t("discovers.show.actions.open"), organization_dashboard_path(organization), class: "du-btn du-btn-primary", data: { turbo: false } %>
+      <% elsif organization.user_requests.pending.exists?(user: current_user) %>
+        <%= link_to t("discovers.show.actions.waiting_for_approval"), "#", class: "du-btn du-btn-primary cursor-not-allowed opacity-70" %>
+      <% elsif organization.user_invitations.pending.exists?(user: current_user) %>
+        <%= button_to t("discovers.show.actions.accept_invitation"), approve_user_invitation_path(organization.user_invitations.pending.find_by(user: current_user)),
+          method: :post,
+          class: "du-btn du-btn-primary",
+          data: { turbo: false } %>
+      <% else %>
+        <%= button_to t("discovers.show.actions.#{organization.privacy_setting_public? ? "join" : "request_to_join"}"), user_membership_requests_path(organization_id: organization.id),
+          method: :post,
+          class: "du-btn du-btn-primary" %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/organizations/access_request/user_request_for_organizations/_user_request_for_organization.html.erb
+++ b/app/views/organizations/access_request/user_request_for_organizations/_user_request_for_organization.html.erb
@@ -1,0 +1,14 @@
+<div class="border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100">
+  <div class="flex items-center gap-2">
+    <%= "User email: #{membership_request.user.email}" %>
+    <br>
+    <%= "Role: #{membership_request.organization_role}" %>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-1">
+      <%= button_to t("membership_requests.buttons.approve"), approve_organization_membership_request_path(@organization, membership_request), method: :post, class: "du-btn du-btn-primary" %>
+      <%= button_to t("membership_requests.buttons.reject"), reject_organization_membership_request_path(@organization, membership_request), method: :post, class: "du-btn du-btn-error" %>
+    </div>
+  </div>
+</div>

--- a/app/views/organizations/membership_requests/index.html.erb
+++ b/app/views/organizations/membership_requests/index.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, t("membership_requests.index.title") %>
+
+<%= render PageComponent.new(title: t("membership_requests.index.page_title", organization: @organization.name)) do |component| %>
+  <div id="membership_requests" class="space-y-4">
+    <% @membership_requests.each do |membership_request| %>
+      <%= render membership_request, membership_request: %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/organizations/memberships/index.html.erb
+++ b/app/views/organizations/memberships/index.html.erb
@@ -22,7 +22,7 @@
     <% end %>
 
     <% if @organization.privacy_setting_restricted? %>
-      <%= link_to "#", class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
+      <%= link_to organization_membership_requests_path(@organization), class: "border p-4 rounded-lg flex items-center justify-between gap-2 hover:bg-gray-100" do %>
         <div class="flex items-center gap-2">
           <%= t(".access_settings.requests_to_join_organization") %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
         cancel: Cancel invitation
       errors:
         not_found: Invitation not found
+    errors:
+      not_found: Organization not found
   discovers:
     show:
       title: Discover
@@ -89,6 +91,8 @@ en:
         join: Join
         request_to_join: Request to join
         open: Open
+        waiting_for_approval: Waiting for approval
+        accept_invitation: Accept invitation
   invitations:
     index:
       title: Pending invitations
@@ -101,6 +105,22 @@ en:
       reject: Reject
     errors:
       not_found: Invitation not found
+  membership_requests:
+    index:
+      title: Membership Requests
+      page_title: Pending membership requests for %{organization}
+    buttons:
+      approve: Approve
+      reject: Reject
+    success: Requested access successfully
+    approve:
+      success: Membership request approved
+    reject:
+      success: Membership request rejected
+    errors:
+      not_found: Membership request not found
+      already_requested: You have already requested access to this organization
+      already_participant: You're already a member of this organization
   shared:
     actions:
       cancel: Cancel

--- a/config/routes/organizations.rb
+++ b/config/routes/organizations.rb
@@ -5,6 +5,12 @@ resources :organizations, path: I18n.t("routes.organizations") do
     resources :memberships, except: %i[show], path: I18n.t("routes.memberships")
     resource :transfer, only: %i[show update]
     resources :invitations, only: %i[index destroy]
+    resources :membership_requests, only: %i[index] do
+      member do
+        post :approve
+        post :reject
+      end
+    end
 
     get "subscriptions", to: "subscriptions#index"
     get "subscriptions/checkout", to: "subscriptions#checkout"

--- a/config/routes/users.rb
+++ b/config/routes/users.rb
@@ -8,5 +8,6 @@ resource :user do
         post :reject
       end
     end
+    resources :membership_requests, only: %i[create]
   end
 end

--- a/test/controllers/organizations/membership_requests_controller_test.rb
+++ b/test/controllers/organizations/membership_requests_controller_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class Organizations::MembershipRequestsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @organization = organizations(:one)
+
+    sign_in @user
+  end
+
+  test "should get index" do
+    get organization_membership_requests_url(@organization)
+    assert_response :success
+  end
+
+  test "should get index and show only pending requests" do
+    pending_requests = @organization.user_requests.pending.to_a
+
+    approved_request = @organization.user_requests.create!(
+      user: users(:two),
+      status: :approved,
+      resources: { organization_role: "member" }.to_json
+    )
+
+    get organization_membership_requests_url(@organization)
+    assert_response :success
+
+    pending_requests.each do |request|
+      assert_match request.user.email, response.body
+    end
+
+    assert_no_match approved_request.user.email, response.body
+  end
+
+  test "should approve membership request for public organization" do
+    membership_request = access_requests(:membership_request_one)
+    membership_request.organization.update!(privacy_setting: :public)
+
+    assert_difference "Membership.count", 1 do
+      assert_no_difference "AccessRequest.count" do
+        post approve_organization_membership_request_url(@organization, membership_request)
+      end
+    end
+
+    assert_equal "approved", membership_request.reload.status
+    assert_redirected_to organization_membership_requests_url(@organization)
+    assert_equal I18n.t("membership_requests.approve.success"), flash[:notice]
+  end
+
+  test "should approve membership request for restricted organization" do
+    membership_request = access_requests(:membership_request_one)
+    membership_request.organization.update!(privacy_setting: :restricted)
+
+    assert_difference "Membership.count", 1 do
+      post approve_organization_membership_request_url(@organization, membership_request)
+    end
+
+    assert_equal "approved", membership_request.reload.status
+    assert_redirected_to organization_membership_requests_url(@organization)
+    assert_equal I18n.t("membership_requests.approve.success"), flash[:notice]
+  end
+
+  test "should reject membership request" do
+    membership_request = access_requests(:membership_request_one)
+
+    assert_no_difference "Membership.count" do
+      assert_no_difference "AccessRequest.count" do
+        post reject_organization_membership_request_url(@organization, membership_request)
+      end
+    end
+
+    assert_equal "rejected", membership_request.reload.status
+    assert_redirected_to organization_membership_requests_url(@organization)
+    assert_equal I18n.t("membership_requests.reject.success"), flash[:notice]
+  end
+
+  test "should catch error if membership request is not found" do
+    membership_request_id = "invalid"
+
+    post reject_organization_membership_request_url(@organization, membership_request_id)
+
+    assert_redirected_to organization_membership_requests_path(@organization)
+    assert_equal I18n.t("membership_requests.errors.not_found"), flash[:alert]
+  end
+end

--- a/test/controllers/users/membership_requests_controller_test.rb
+++ b/test/controllers/users/membership_requests_controller_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class Users::MembershipRequestsControllerTest < ActionDispatch::IntegrationTest
+  test "should create membership for public organization" do
+    membership = memberships(:one)
+    user = membership.user
+    requested_organization = organizations(:three)
+    requested_organization.privacy_setting_public!
+
+    sign_in user
+
+    assert_difference "Membership.count", 1 do
+      post user_membership_requests_url(organization_id: requested_organization.id)
+    end
+
+    assert_equal 200, response.status
+    assert_equal I18n.t("membership_requests.success"), flash[:notice]
+  end
+
+  test "should create membership request for restricted organization" do
+    membership = memberships(:one)
+    user = membership.user
+    requested_organization = organizations(:three)
+    requested_organization.privacy_setting_restricted!
+
+    sign_in user
+
+    assert_difference "AccessRequest::UserRequestForOrganization.count", 1 do
+      post user_membership_requests_url(organization_id: requested_organization.id)
+    end
+
+    assert_equal 200, response.status
+    assert_equal I18n.t("membership_requests.success"), flash[:notice]
+  end
+
+  test "should not create membership request if request params are not valid" do
+    membership = memberships(:one)
+    user = membership.user
+    requested_organization = organizations(:one)
+
+    sign_in user
+
+    assert_no_difference "AccessRequest::UserRequestForOrganization.count" do
+      assert_no_difference "Membership.count" do
+        post user_membership_requests_url(organization_id: requested_organization.id)
+      end
+    end
+
+    assert_equal 200, response.status
+    assert_equal I18n.t("membership_requests.errors.already_participant"), flash[:alert]
+  end
+
+  test "should catch error if organization is not found" do
+    membership = memberships(:one)
+    user = membership.user
+    organization_id = "invalid"
+
+    sign_in user
+
+    post user_membership_requests_url(organization_id:)
+
+    assert_redirected_to discover_path
+    assert_equal I18n.t("organizations.errors.not_found"), flash[:alert]
+  end
+end

--- a/test/fixtures/access_requests.yml
+++ b/test/fixtures/access_requests.yml
@@ -13,3 +13,10 @@ invite_to_organization_two:
   status: pending
   type: AccessRequest::InviteToOrganization
   resources: '{ "organization_role": "member" }'
+
+membership_request_one:
+  organization: one
+  user: three
+  status: pending
+  type: AccessRequest::UserRequestForOrganization
+  resources: '{ "organization_role": "member" }'

--- a/test/fixtures/organizations.yml
+++ b/test/fixtures/organizations.yml
@@ -7,3 +7,7 @@ one:
 two:
   name: Organization 2
   owner: two
+
+three:
+  name: Organization 3
+  owner: three

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,5 +10,8 @@ one:
 two:
   email: hello@superails.com
 
+three:
+  email: natan@superails.com
+
 unassociated:
   email: unassociated@superails.com

--- a/test/models/access_request_test.rb
+++ b/test/models/access_request_test.rb
@@ -11,7 +11,7 @@ class AccessRequestTest < ActiveSupport::TestCase
     rejected_access_request = AccessRequest.create!(status: :rejected, user: users(:one), organization: organizations(:one))
     pending_access_requests = AccessRequest.pending
 
-    assert_equal 2, pending_access_requests.count
+    assert_equal 3, pending_access_requests.count
     assert_includes pending_access_requests, access_requests(:invite_to_organization_one)
     assert_includes pending_access_requests, access_requests(:invite_to_organization_two)
     assert_not_includes pending_access_requests, rejected_access_request


### PR DESCRIPTION
- Introduced `Organizations::MembershipRequestsController` for handling membership requests, including approval and rejection actions.
- Created `Users::MembershipRequestsController` for users to submit membership requests to organizations.
- Added `MembershipRequest` model to manage request logic and validations.
- Updated views for displaying and managing membership requests, including new index and user request forms.