### PR TITLE
Fix: allow users to be re-invited after declining

### DIFF
--- a/app/models/access_request/invite_to_organization.rb
+++ b/app/models/access_request/invite_to_organization.rb
@@ -14,8 +14,8 @@ class AccessRequest::InviteToOrganization < AccessRequest
     raise ActiveRecord::Rollback, e.message
   end
 
-  def reject!(completed_by: user)
-    update!(status: :rejected, completed_by: completed_by)
+  def reject!(completed_by: user) # rubocop:disable Lint/UnusedMethodArgument
+    destroy!
   end
 
   private

--- a/app/models/access_request/user_request_for_organization.rb
+++ b/app/models/access_request/user_request_for_organization.rb
@@ -13,8 +13,8 @@ class AccessRequest::UserRequestForOrganization < AccessRequest
     raise ActiveRecord::Rollback, e.message
   end
 
-  def reject!(completed_by:)
-    update!(status: :rejected, completed_by:)
+  def reject!(completed_by:) # rubocop:disable Lint/UnusedMethodArgument
     Membership::RequestRejectedNotifier.with(organization: organization).deliver(user)
+    destroy!
   end
 end

--- a/test/controllers/organizations/received_join_requests_controller_test.rb
+++ b/test/controllers/organizations/received_join_requests_controller_test.rb
@@ -63,14 +63,15 @@ class Organizations::ReceivedJoinRequestsControllerTest < ActionDispatch::Integr
 
   test "should reject join request" do
     join_request = access_requests(:membership_request_one)
+    join_request_id = join_request.id
 
     assert_no_difference "Membership.count" do
-      assert_no_difference "AccessRequest.count" do
+      assert_difference "AccessRequest.count", -1 do
         post reject_organization_received_join_request_url(@organization, join_request)
       end
     end
 
-    assert_equal "rejected", join_request.reload.status
+    assert_not AccessRequest.exists?(join_request_id)
     assert_redirected_to organization_received_join_requests_url(@organization)
     assert_equal I18n.t("join_requests.reject.success"), flash[:notice]
   end

--- a/test/controllers/users/organizations/received_invitations_controller_test.rb
+++ b/test/controllers/users/organizations/received_invitations_controller_test.rb
@@ -29,13 +29,17 @@ class Users::Organizations::ReceivedInvitationsControllerTest < ActionDispatch::
   end
 
   test "should decline invitation" do
-    assert_difference "@unassociated_user.memberships.count", 0 do
-      patch decline_user_organizations_received_invitation_url(@invitation)
+    invitation_id = @invitation.id
+
+    assert_no_difference "@unassociated_user.memberships.count" do
+      assert_difference "AccessRequest.count", -1 do
+        patch decline_user_organizations_received_invitation_url(@invitation)
+      end
     end
 
     assert_redirected_to user_organizations_received_invitations_url
     assert_equal I18n.t("invitations.decline.success"), flash[:notice]
-    assert_equal "rejected", @invitation.reload.status
+    assert_not AccessRequest.exists?(invitation_id)
   end
 
   test "should not accept invitation if not signed in" do

--- a/test/models/access_request/invite_to_organization_test.rb
+++ b/test/models/access_request/invite_to_organization_test.rb
@@ -27,12 +27,14 @@ class AccessRequest::InviteToOrganizationTest < ActiveSupport::TestCase
     assert_equal "approved", access_request.reload.status
   end
 
-  test "when rejected, updates the access request status" do
+  test "when rejected, destroys the access request" do
     access_request = access_requests(:invite_to_organization_one)
-    assert_difference "Membership.count", 0 do
-      access_request.reject!
+    assert_no_difference "Membership.count" do
+      assert_difference "AccessRequest.count", -1 do
+        access_request.reject!
+      end
     end
 
-    assert_equal "rejected", access_request.reload.status
+    assert_not AccessRequest.exists?(access_request.id)
   end
 end


### PR DESCRIPTION
## Summary

- When a user declines an invitation or admin rejects a join request, the `AccessRequest` record is now **destroyed** instead of kept with `rejected` status
- This removes the blocking uniqueness constraint that prevented re-invitations
- Notification is still sent before destroying when admin rejects a join request

## Problem

The uniqueness constraint on `user_id + organization_id` blocked ALL records, not just pending ones. Once rejected/declined, users could never be invited again.

| Scenario | Before | After |
|----------|--------|-------|
| User declines invitation, later wants to join | ❌ Blocked | ✅ Can request |
| User's join request rejected, org reconsiders | ❌ Blocked | ✅ Can re-invite |

## Test plan

- [x] `rails test test/models/access_request/` - all pass
- [x] `rails test test/controllers/organizations/received_join_requests_controller_test.rb` - all pass
- [x] `rails test test/controllers/users/organizations/received_invitations_controller_test.rb` - all pass
- [x] `bundle exec rubocop` - no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)