### PR TITLE
Remove 7-day expiration from invitations

### DIFF
--- a/app/controllers/users/invitation_acceptances_controller.rb
+++ b/app/controllers/users/invitation_acceptances_controller.rb
@@ -44,11 +44,6 @@ class Users::InvitationAcceptancesController < ApplicationController
     token = params[:invitation_token].to_s.presence || session[:invitation_token].to_s
     # Normalize token to prevent timing attacks
     @user = User.find_by(invitation_token: token) if token.present?
-    # Always check expiration to normalize timing
-    return unless @user&.invitation_created_at && @user.invitation_created_at < 7.days.ago
-
-    @user = nil
-    session.delete(:invitation_token) if @user.nil?
   end
 
   def ensure_valid_invitation

--- a/test/controllers/users/invitation_acceptances_controller_test.rb
+++ b/test/controllers/users/invitation_acceptances_controller_test.rb
@@ -104,16 +104,16 @@ class Users::InvitationAcceptancesControllerTest < ActionDispatch::IntegrationTe
     assert_equal I18n.t("users.invitation_acceptances.new.invalid_token"), flash[:alert]
   end
 
-  test "should redirect if token expired" do
+  test "should accept old invitations (invitations never expire)" do
     inviter = users(:one)
     organization = organizations(:one)
     invited_user = User.invite!({ email: "invited@example.com" }, inviter)
     organization.sent_invitations.create!(user: invited_user)
-    invited_user.update!(invitation_created_at: 8.days.ago)
+    invited_user.update!(invitation_created_at: 30.days.ago)
 
     get accept_user_invitation_url(invitation_token: invited_user.invitation_token)
-    assert_redirected_to new_user_session_url
-    assert_equal I18n.t("users.invitation_acceptances.new.invalid_token"), flash[:alert]
+    assert_response :success
+    assert_match invited_user.email, response.body
   end
 
   test "should not accept already accepted invitation" do


### PR DESCRIPTION
## Summary
- Remove the 7-day expiration check from invitation acceptance
- Invitations now remain valid until manually cancelled by an admin
- Update test to verify old invitations are still accepted

## Test plan
- [x] All existing invitation acceptance tests pass
- [x] Test verifies 30-day-old invitation is still accepted
- [ ] Manual test: create invitation, set `invitation_created_at` to old date, verify link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)