### PR TITLE
Implement comprehensive accessibility improvements (WCAG 2.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,53 @@ Use `before_action :require_subscription` for paywalled features.
 - Never query without organization scope
 - Use `ObfuscatesId` concern for public-facing IDs
 
+## Accessibility
+
+Based on [Accessibility essentials every front-end developer should know](https://martijnhols.nl/blog/accessibility-essentials-every-front-end-developer-should-know).
+
+### Semantic HTML
+
+- Never use `<div>` or `<tr>` with `onclick` for interactive elements. Use `<a>` for navigation and `<button>` for actions.
+- Use proper list elements (`<ul>/<ol>` with `<li>`). Don't misuse `<dl>` without `<dt>/<dd>` pairs.
+- Use semantic landmarks: `<main>`, `<nav>`, `<header>`, `<footer>`, `<aside>`, `<section>`.
+
+### Images & Icons
+
+- All `<img>` tags must have an `alt` attribute. Use `alt=""` only for purely decorative images.
+- Decorative SVGs and icons must have `aria-hidden="true"` (the `nav_link` helper and `TabsComponent` handle this automatically).
+- Emoji icons used as meaningful indicators need `role="img"` and `aria-label` (see `privacy_setting_icon`).
+- Don't use `alt` on `<span>` elements — it's not a valid attribute. Use `aria-label` instead.
+
+### Focus & Keyboard Navigation
+
+- Never remove focus indicators entirely. The app uses `:focus` with a primary-color glow effect.
+- All interactive elements must be keyboard-accessible (focusable, activatable with Enter/Space).
+- Skip navigation links are present in all layouts — maintain these when adding new layouts.
+- Modals must restore focus to the trigger element on close (handled by `dialog_controller.js`).
+
+### ARIA
+
+- Use `aria-label` on buttons/controls that have no visible text (e.g., icon-only buttons).
+- Use `role="alert"` on error messages and flash notifications so screen readers announce them.
+- Use `aria-labelledby` to associate modal titles with `<dialog>` elements.
+- Use `aria-hidden="true"` on decorative elements that duplicate adjacent text labels.
+
+### Forms
+
+- All form inputs must have associated labels. Use SimpleForm which generates labels automatically.
+- The language picker uses a `<label class="sr-only">` for its `<select>`.
+- Use `autocomplete` attributes on login/registration fields.
+
+### Motion & Zoom
+
+- `prefers-reduced-motion: reduce` is respected globally — all animations and transitions are disabled.
+- Never restrict zoom (`user-scalable=0`, `maximum-scale=1`) in regular mobile browsers (WCAG 1.4.4). Only restrict in native app shells (`hotwire_native_app?`).
+
+### JavaScript
+
+- Use Stimulus controllers instead of inline event handlers (`onclick`, `onchange`).
+- The `locale_picker_controller.js` handles language switching; `dialog_controller.js` handles modal focus management.
+
 ## Git Workflow
 
 - **Never commit directly to main/master** - always create a feature branch

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -184,6 +184,18 @@
   }
 }
 
+/* Respect reduced motion preferences (WCAG 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .prose pre {
   @apply max-lg:w-sm;
 }

--- a/app/components/empty_state_component.rb
+++ b/app/components/empty_state_component.rb
@@ -13,11 +13,11 @@ class EmptyStateComponent < ViewComponent::Base
     return if icon.blank?
 
     if icon.match?(/svg/)
-      helpers.inline_svg_tag icon, class: "w-10 h-10 size-10 text-base-content/50"
+      helpers.inline_svg_tag icon, class: "w-10 h-10 size-10 text-base-content/50", "aria-hidden": "true"
     elsif icon&.start_with?("http") || icon&.match?(/\.(png|jpg|webp|avif|gif)$/)
-      image_tag icon, class: "w-10 h-10 rounded object-cover"
+      image_tag icon, class: "w-10 h-10 rounded object-cover", alt: "", "aria-hidden": "true"
     else
-      tag.span icon, class: "text-4xl"
+      tag.span icon, class: "text-4xl", "aria-hidden": "true"
     end
   end
 end

--- a/app/components/tabs_component.html.erb
+++ b/app/components/tabs_component.html.erb
@@ -15,11 +15,11 @@
           <% else %>
             <% if tab[:icon] %>
               <% if tab[:icon].match?(/svg/) %>
-                <%= helpers.inline_svg_tag tab[:icon], class: "size-6 w-6 h-6" %>
+                <%= helpers.inline_svg_tag tab[:icon], class: "size-6 w-6 h-6", "aria-hidden": "true" %>
               <% elsif tab[:icon].start_with?("http") || tab[:icon].match?(/\.(png|jpg|webp|avif|gif)$/) %>
-                <%= image_tag tab[:icon], class: "size-6 w-6 h-6 rounded" %>
+                <%= image_tag tab[:icon], class: "size-6 w-6 h-6 rounded", alt: "", "aria-hidden": "true" %>
               <% else %>
-                <%= tag.span tab[:icon] %>
+                <%= tag.span tab[:icon], "aria-hidden": "true" %>
               <% end %>
             <% end %>
             <%= tab[:label] %>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,11 +12,11 @@ module ApplicationHelper
 
   def nav_link(label, path, icon: nil, badge: nil, todo_dot: false, wrapper: :li, **)
     resolved_icon = if icon&.match?(/svg/)
-                      inline_svg_tag icon, class: "size-6 w-6 h-6"
+                      inline_svg_tag icon, class: "size-6 w-6 h-6", "aria-hidden": "true"
                     elsif icon&.start_with?("http") || icon&.match?(/\.(png|jpg|webp|avif|gif)$/)
-                      image_tag icon, class: "size-6 w-6 h-6 rounded"
+                      image_tag icon, class: "size-6 w-6 h-6 rounded", alt: "", "aria-hidden": "true"
                     else
-                      icon
+                      icon.is_a?(String) && !icon.html_safe? ? content_tag(:span, icon, "aria-hidden": "true") : icon
                     end
 
     badge_span = content_tag(:span, badge, class: "badge badge-xs badge-warning") if badge.present?
@@ -132,10 +132,11 @@ module ApplicationHelper
     parts.join(" - ")
   end
 
-  # forbid zooming on mobile devices
+  # Only restrict zoom in native app containers where pinch-to-zoom is handled natively.
+  # Regular mobile browsers must allow zoom per WCAG 1.4.4 (Resize Text).
   def viewport_meta_tag
     content = ["width=device-width,initial-scale=1,viewport-fit=cover"]
-    content << "maximum-scale=1, user-scalable=0" if hotwire_native_app? || browser.device.mobile?
+    content << "maximum-scale=1, user-scalable=0" if hotwire_native_app?
     tag.meta name: "viewport", content: content.join(",")
   end
 end

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -35,7 +35,7 @@ module OrganizationsHelper
   end
 
   def privacy_setting_icon(key)
-    tag.span privacy_setting_options(key)[:icon], class: "text-lg", alt: key, title: privacy_setting_options(key)[:display_text]
+    tag.span privacy_setting_options(key)[:icon], class: "text-lg", role: "img", "aria-label": privacy_setting_options(key)[:display_text], title: privacy_setting_options(key)[:display_text]
   end
 
   def organization_tabs

--- a/app/javascript/controllers/dialog_controller.js
+++ b/app/javascript/controllers/dialog_controller.js
@@ -2,13 +2,19 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   connect() {
+    // Store the element that had focus before opening the modal
+    this.previouslyFocusedElement = document.activeElement
     this.open()
     // needed because ESC key does not trigger close event
-    this.element.addEventListener('close', this.enableBodyScroll.bind(this))
+    this.boundEnableBodyScroll = this.enableBodyScroll.bind(this)
+    this.boundRestoreFocus = this.restoreFocus.bind(this)
+    this.element.addEventListener('close', this.boundEnableBodyScroll)
+    this.element.addEventListener('close', this.boundRestoreFocus)
   }
 
   disconnect() {
-    this.element.removeEventListener('close', this.enableBodyScroll.bind(this))
+    this.element.removeEventListener('close', this.boundEnableBodyScroll)
+    this.element.removeEventListener('close', this.boundRestoreFocus)
   }
 
   // hide modal on successful form submission
@@ -22,9 +28,6 @@ export default class extends Controller {
   open() {
     this.element.showModal()
     document.body.classList.add('overflow-hidden')
-
-    // Remove focus from auto-focused element (usually close button)
-    document.activeElement.blur()
   }
 
   close() {
@@ -32,6 +35,13 @@ export default class extends Controller {
     const frame = document.getElementById('modal')
     frame.removeAttribute('src')
     frame.innerHTML = ''
+  }
+
+  restoreFocus() {
+    if (this.previouslyFocusedElement && this.previouslyFocusedElement.focus) {
+      this.previouslyFocusedElement.focus()
+      this.previouslyFocusedElement = null
+    }
   }
 
   enableBodyScroll() {

--- a/app/javascript/controllers/locale_picker_controller.js
+++ b/app/javascript/controllers/locale_picker_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  navigate(event) {
+    const url = event.target.value
+    if (url) {
+      window.location.href = url
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,10 @@
   <head><%= render "layouts/head" %></head>
 
   <body class="h-dvh overflow-hidden">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-primary focus:text-primary-content focus:top-0 focus:left-0">
+      Skip to main content
+    </a>
+
     <div class="drawer lg:drawer-open">
       <input id="main-drawer" type="checkbox" class="drawer-toggle">
 
@@ -25,7 +29,7 @@
           </div>
         </div>
 
-        <main class="flex-grow p-4 min-w-0 overflow-x-hidden">
+        <main id="main-content" class="flex-grow p-4 min-w-0 overflow-x-hidden">
           <%= yield %>
         </main>
 

--- a/app/views/layouts/centered.html.erb
+++ b/app/views/layouts/centered.html.erb
@@ -4,11 +4,15 @@
   <head><%= render "layouts/head" %></head>
 
   <body class="flex flex-col min-h-screen">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-primary focus:text-primary-content focus:top-0 focus:left-0">
+      Skip to main content
+    </a>
+
     <div class="flex-grow flex flex-col bg-base-300">
       <header class="sticky z-20 top-0">
         <nav class="flex justify-center px-6 py-4 bg-base-100">
           <%= link_to root_path, class: "no-underline" do %>
-            <%= image_tag "logo-long.png", class: "w-auto h-8 dark:invert" %>
+            <%= image_tag "logo-long.png", alt: Rails.application.config_for(:settings).dig(:site, :name), class: "w-auto h-8 dark:invert" %>
           <% end %>
         </nav>
 
@@ -25,7 +29,7 @@
         </div>
       </header>
 
-      <main class="flex-grow flex flex-col items-center pt-12 lg:pt-20 px-4 lg:px-10 bg-base-100">
+      <main id="main-content" class="flex-grow flex flex-col items-center pt-12 lg:pt-20 px-4 lg:px-10 bg-base-100">
         <div class="w-full max-w-lg"><%= yield %></div>
       </main>
     </div>

--- a/app/views/layouts/static.html.erb
+++ b/app/views/layouts/static.html.erb
@@ -4,6 +4,10 @@
   <head><%= render "layouts/head" %></head>
 
   <body class="flex flex-col min-h-screen">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-primary focus:text-primary-content focus:top-0 focus:left-0">
+      Skip to main content
+    </a>
+
     <div class="flex-grow flex flex-col bg-base-300">
       <header class="sticky z-20 top-0">
         <%= render "shared/unauthenticated_navbar" %>
@@ -21,7 +25,7 @@
         </div>
       </header>
 
-      <main class="flex-grow p-4 lg:p-10 bg-base-100"><%= yield %></main>
+      <main id="main-content" class="flex-grow p-4 lg:p-10 bg-base-100"><%= yield %></main>
 
       <%= render "shared/footer" %>
     </div>

--- a/app/views/organizations/subscriptions/_features.html.erb
+++ b/app/views/organizations/subscriptions/_features.html.erb
@@ -1,7 +1,7 @@
 <%= render SectionComponent.new(title: t("organizations.subscriptions.features.title"), full_width: false) do %>
-  <dl class="space-y-2">
+  <ul class="space-y-2">
     <% Rails.application.config_for(:settings)[:pro_features].map do |feature| %>
-      <div><%= feature %></div>
+      <li><%= feature %></li>
     <% end %>
-  </dl>
+  </ul>
 <% end %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -2,6 +2,7 @@
   <div
     id="error_explanation"
     class="alert alert-error"
+    role="alert"
     data-turbo-cache="false"
   >
     <div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
   <aside>
     <div>
       <%= link_to root_path, class: "no-underline" do %>
-        <%= image_tag "logo-long.png", class: "w-auto h-8 dark:invert" %>
+        <%= image_tag "logo-long.png", alt: Rails.application.config_for(:settings).dig(:site, :name), class: "w-auto h-8 dark:invert" %>
       <% end %>
     </div>
     &copy;

--- a/app/views/shared/_language_picker.html.erb
+++ b/app/views/shared/_language_picker.html.erb
@@ -1,4 +1,7 @@
 <% if I18n.available_locales.count > 1 %>
   <% options = I18n.available_locales.map { |locale| [locale_to_flag(locale), url_for(locale: locale)] } %>
-  <%= select_tag :locale, options_for_select(options, url_for(locale: I18n.locale)), onchange: "window.location.href=this.value", class: "select select-bordered w-full" %>
+  <div data-controller="locale-picker">
+    <label for="locale" class="sr-only"><%= t("shared.language_picker.label", default: "Language") %></label>
+    <%= select_tag :locale, options_for_select(options, url_for(locale: I18n.locale)), data: { action: "change->locale-picker#navigate" }, class: "select select-bordered w-full" %>
+  </div>
 <% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -18,7 +18,7 @@
 
           <form method="dialog">
             <button class="btn btn-sm btn-circle btn-ghost" aria-label="Close dialog">
-              <%= inline_svg_tag "svg/x-mark.svg", class: "size-4" %>
+              <%= inline_svg_tag "svg/x-mark.svg", class: "size-4", "aria-hidden": "true" %>
             </button>
           </form>
         </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,7 +2,7 @@
   <%# left %>
   <div class="flex items-center gap-2">
     <%# mobile sidebar toggle %>
-    <label for="main-drawer" class="btn btn-ghost btn-square lg:hidden" aria-label="Toggle menu"><%= inline_svg_tag "svg/bars-3.svg", class: "size-6" %></label>
+    <label for="main-drawer" class="btn btn-ghost btn-square lg:hidden" aria-label="Toggle menu"><%= inline_svg_tag "svg/bars-3.svg", class: "size-6", "aria-hidden": "true" %></label>
 
     <%# select org dropdown %>
     <% if Current.organization %>
@@ -10,7 +10,7 @@
         <div tabindex="0" role="button" class="btn btn-ghost" aria-label="Select organization">
           <%= organization_avatar(Current.organization, classes: "size-6") %>
           <%= Current.organization.name.truncate(15) %>
-          <%= inline_svg_tag "svg/chevron-down.svg", class: "w-4 h-4 stroke-2 transition-transform duration-200 group-focus-within:rotate-180" %>
+          <%= inline_svg_tag "svg/chevron-down.svg", class: "w-4 h-4 stroke-2 transition-transform duration-200 group-focus-within:rotate-180", "aria-hidden": "true" %>
         </div>
 
         <ul
@@ -41,7 +41,7 @@
     <div class="dropdown dropdown-end max-lg:hidden">
       <div tabindex="0" role="button" class="btn btn-ghost btn-circle" aria-label="Notifications">
         <%= render "users/notifications/notifications_count", unread: current_user.unseen_notifications_count %>
-        <%= inline_svg_tag "svg/bell.svg", class: "w-6 h-6" %>
+        <%= inline_svg_tag "svg/bell.svg", class: "w-6 h-6", "aria-hidden": "true" %>
       </div>
 
       <div
@@ -58,7 +58,7 @@
     </div>
 
     <div class="dropdown dropdown-end group">
-      <div tabindex="0" role="button" class="cursor-pointer"><%= user_avatar(current_user) %></div>
+      <div tabindex="0" role="button" class="cursor-pointer" aria-label="User menu"><%= user_avatar(current_user) %></div>
 
       <div
         tabindex="-1"

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -57,7 +57,7 @@
           <li>
             <details>
               <summary>
-                <%= inline_svg_tag "svg/cog-6-tooth.svg", class: "size-6 w-6 h-6" %>
+                <%= inline_svg_tag "svg/cog-6-tooth.svg", class: "size-6 w-6 h-6", "aria-hidden": "true" %>
 
                 <span class="[[data-expanded=false]_&]:hidden truncate"> Admin </span>
               </summary>

--- a/app/views/shared/_unauthenticated_navbar.html.erb
+++ b/app/views/shared/_unauthenticated_navbar.html.erb
@@ -3,8 +3,8 @@
   <div class="flex items-center gap-2">
     <div>
       <%= link_to root_path, class: "no-underline" do %>
-        <%= image_tag "logo.png", class: "size-8 lg:hidden dark:invert" %>
-        <%= image_tag "logo-long.png", class: "w-auto h-8 hidden lg:block dark:invert" %>
+        <%= image_tag "logo.png", alt: Rails.application.config_for(:settings).dig(:site, :name), class: "size-8 lg:hidden dark:invert" %>
+        <%= image_tag "logo-long.png", alt: Rails.application.config_for(:settings).dig(:site, :name), class: "w-auto h-8 hidden lg:block dark:invert" %>
       <% end %>
     </div>
 

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -11,7 +11,7 @@
 
       <% if sign_in_account %>
         <div class="flex items-center gap-1.5 mt-1">
-          <%= inline_svg_tag "svg/#{ConnectedAccount::PROVIDER_CONFIG[sign_in_account.provider.to_sym][:icon]}.svg", class: "w-4 h-4" %>
+          <%= inline_svg_tag "svg/#{ConnectedAccount::PROVIDER_CONFIG[sign_in_account.provider.to_sym][:icon]}.svg", class: "w-4 h-4", "aria-hidden": "true" %>
 
           <span class="text-xs text-base-content/60">
             <%= ConnectedAccount::PROVIDER_CONFIG[sign_in_account.provider.to_sym][:name] %>

--- a/app/views/users/notifications/_notification.html.erb
+++ b/app/views/users/notifications/_notification.html.erb
@@ -1,10 +1,9 @@
 <tr
   id="notification_<%= notification.id %>"
-  class="<%= notification.seen? ? "bg-base-100" : "bg-primary/10" %> hover:bg-base-200 transition-colors duration-200 cursor-pointer"
-  onclick="window.location='<%= notification.url %>'"
+  class="<%= notification.seen? ? "bg-base-100" : "bg-primary/10" %> hover:bg-base-200 transition-colors duration-200"
 >
   <td>
-    <div class="flex items-center gap-3">
+    <%= link_to notification.url, class: "flex items-center gap-3 no-underline text-inherit" do %>
       <% if notification.respond_to?(:icon) && notification.icon.present? %>
         <%= notification.icon %>
       <% else %>
@@ -12,7 +11,7 @@
       <% end %>
 
       <span class="text-sm text-base-content"><%= notification.message %></span>
-    </div>
+    <% end %>
   </td>
 
   <td><%= time_ago_in_words(notification.created_at) %> ago</td>


### PR DESCRIPTION
## Summary

This PR implements comprehensive accessibility improvements across the application to meet WCAG 2.1 standards. Changes include semantic HTML fixes, proper ARIA attributes, keyboard navigation support, focus management, and motion preferences handling.

## Key Changes

### Documentation & Guidelines
- Added detailed accessibility guidelines to `CLAUDE.md` covering semantic HTML, images/icons, focus management, ARIA, forms, motion, and JavaScript best practices

### Semantic HTML & Structure
- Fixed notification table rows: replaced `onclick` handler with proper `<a>` link wrapper for keyboard accessibility
- Fixed feature list: changed from misused `<dl>` to proper `<ul>/<li>` structure
- Added `id="main-content"` anchors to all layout templates for skip navigation links
- Added skip-to-main-content links in all layouts (application, centered, static) with proper styling

### Images & Icons
- Added `alt` attributes to all logo images with site name fallback
- Added `aria-hidden="true"` to all decorative SVG icons and images throughout components and views
- Fixed `privacy_setting_icon` helper: changed from invalid `alt` on `<span>` to proper `role="img"` and `aria-label`

### Forms & Interaction
- Converted language picker from inline `onchange` handler to Stimulus controller (`locale_picker_controller.js`)
- Added `<label class="sr-only">` for language picker accessibility
- Added `role="alert"` to error messages for screen reader announcements

### Focus & Keyboard Navigation
- Enhanced `dialog_controller.js` to restore focus to trigger element when modal closes (WCAG 2.4.3)
- Removed automatic blur of focused elements in modals
- Added `aria-label` to user menu button

### Motion & Zoom
- Added global `prefers-reduced-motion: reduce` media query to disable animations for users with motion sensitivity
- Fixed viewport meta tag: removed `user-scalable=0` restriction for regular mobile browsers (only restrict in native app shells per WCAG 1.4.4)

### Component Updates
- Updated `empty_state_component.rb` to add `aria-hidden="true"` to decorative icons
- Updated `tabs_component.html.erb` to add `aria-hidden="true"` to tab icons
- Updated `nav_link` helper to properly handle emoji icons with `aria-hidden` wrapper

## Implementation Details

- All decorative SVGs and images now have `aria-hidden="true"` to prevent screen reader clutter
- Meaningful emoji icons use `role="img"` with `aria-label` for proper semantic meaning
- Focus restoration in modals uses event listener cleanup to prevent memory leaks
- Stimulus controllers replace inline event handlers for better maintainability and accessibility
- Skip navigation links use Tailwind's `sr-only` and `focus:not-sr-only` utilities for keyboard-only visibility

https://claude.ai/code/session_016dLbGjCok7srCAqX5uH6pt