### PR TITLE
Sign Out error fix

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -34,6 +34,7 @@
 <%# Includes all stylesheet files in app/assets/stylesheets %>
 
 <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+<%= javascript_include_tag "turbo", type: "module" %>
 <%= stylesheet_link_tag "lexxy-variables", "lexxy-editor", "lexxy-content" %>
 
 <%= javascript_importmap_tags %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete, :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :delete, :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
## Linked issue

https://github.com/yshmarov/moneygun/issues/340

## Solution Reference

~https://github.com/heartcombo/devise/issues/5439#issuecomment-998208004~
https://discuss.rubyonrails.org/t/guide-v7-0-3-1-link-to-destroy-turbo-method-delete-doesnt-works-ubuntu-22-04/81326/8

## What changed

~Added get method in devise config~
Added script to include turbo module in app header

## Why

Current sign out link redirect to GET method which is normal occurence in using turbo method with `link_to` instead of `button_to`

## Checklist

- [x] Tests pass (`rails test:all`)
- [x] Linters pass (`bundle exec rubocop -A && bundle exec erb_lint --lint-all -a`)
- [ ] Scoped queries to organization where applicable
